### PR TITLE
feat: Add config to change columns and pivot

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,34 @@ This is the contents of the published config file:
 
 ```php
 return [
-    // TODO
+    'approval' => [
+
+        /**
+         * The column name for new data.
+         *
+         * Default: 'new_data'
+         */
+        'new_data' => 'new_data',
+
+
+        /**
+         * The column name for original data
+         *
+         * Default: 'original_data
+         */
+        'original_data' => 'original_data',
+
+        /**
+         * The approval polymorphic pivot name
+         *
+         * Default: 'approvalable'
+         */
+        'approval_pivot' => 'approvalable',
+    ],
 ];
 ```
+
+The config allows you to change the column names as well as the polymorphic pivot name. The latter should always end with `able` though.
 
 ## Usage
 

--- a/config/approval.php
+++ b/config/approval.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    'approval' => [
+
+        /**
+         * The column name for new data.
+         *
+         * Default: 'new_data'
+         */
+        'new_data' => 'new_data',
+
+
+        /**
+         * The column name for original data
+         *
+         * Default: 'original_data
+         */
+        'original_data' => 'original_data',
+
+        /**
+         * The approval polymorphic pivot name
+         *
+         * Default: 'approvalable'
+         */
+        'approval_pivot' => 'approvalable',
+    ],
+];

--- a/database/migrations/2022_02_12_195950_create_approvals_table.php
+++ b/database/migrations/2022_02_12_195950_create_approvals_table.php
@@ -4,15 +4,16 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up()
     {
         Schema::create('approvals', function (Blueprint $table) {
             $table->id();
-            $table->morphs('approvalable');
+            $table->morphs(config(key: 'approval.approval.approval_pivot'));
             $table->enum('state', [0, 1, 2])->default(0)->comment('0:PENDING, 1:APPROVED, 2:REJECTED');
-            $table->json('new_data')->nullable();
-            $table->json('original_data')->nullable();
+            $table->json(config(key: 'approval.approval.new_data'))->nullable();
+            $table->json(config(key: 'approval.approval.original_data'))->nullable();
             $table->timestamps();
         });
     }

--- a/src/ApprovalServiceProvider.php
+++ b/src/ApprovalServiceProvider.php
@@ -10,7 +10,8 @@ class ApprovalServiceProvider extends PackageServiceProvider
     public function configurePackage(Package $package): void
     {
         $package
-            ->name('approval')
-            ->hasMigration('2022_02_12_195950_create_approvals_table');
+            ->name(name: 'approval')
+            ->hasConfigFile()
+            ->hasMigration(migrationFileName: '2022_02_12_195950_create_approvals_table');
     }
 }

--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -22,8 +22,8 @@ trait MustBeApproved
             }
 
             $model->approvals()->create([
-                'new_data' => $model->when($model->wasChanged(), fn () => $model->getChanges()),
-                'original_data' => $model->when($model->wasChanged(), fn () => $model->getOriginalMatchingChanges()),
+                (string)config(key: 'approval.approval.new_data') => $model->when($model->wasChanged(), fn () => $model->getChanges()),
+                (string)config(key: 'approval.approval.original_data') => $model->when($model->wasChanged(), fn () => $model->getOriginalMatchingChanges()),
             ]);
         });
     }
@@ -35,7 +35,7 @@ trait MustBeApproved
 
     public function approvals(): MorphMany
     {
-        return $this->morphMany(related: Approval::class, name: 'approvalable');
+        return $this->morphMany(related: Approval::class, name: config(key: 'approval.approval.approval_pivot'));
     }
 
     protected function getOriginalMatchingChanges(): Collection

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -12,8 +12,8 @@ class Approval extends Model
     protected $guarded = [];
 
     protected $casts = [
-        'new_data' => AsArrayObject::class,
-        'original_data' => AsArrayObject::class,
+        "{config('approval.approval.new_data')}" => AsArrayObject::class,
+        "{config('approval.approval.original_data')}" => AsArrayObject::class,
         'state' => ApprovalStatus::class,
     ];
 

--- a/tests/Feature/MustBeApprovedTraitTest.php
+++ b/tests/Feature/MustBeApprovedTraitTest.php
@@ -12,7 +12,8 @@ beforeEach(function () {
         'original_data' => '{"name":"Bob"}',
     ];
 });
-it('stores the data correctly in the database')
+
+it(description: 'stores the data correctly in the database')
     ->tap(
         fn () => Approval::create($this->approvalData)
     )->assertDatabaseHas('approvals', [


### PR DESCRIPTION
This PR adds a config file that allows you to change some defaults.

You can change these database column names:

- `new_data`
- `original_data`

to whatever you see fit. This must be done before you migrate.

The polymorphic pivot table name is also amendable. The default is:

- `approvalable`

> If changing this, it must end with the suffix `able` otherwise it will fail