### PR TITLE
fix: Switch Enum data from INT to STRING

### DIFF
--- a/database/migrations/2022_02_12_195950_create_approvals_table.php
+++ b/database/migrations/2022_02_12_195950_create_approvals_table.php
@@ -8,10 +8,10 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create('approvals', function (Blueprint $table) {
+        Schema::create(table: 'approvals', callback: function (Blueprint $table) {
             $table->id();
             $table->morphs(config(key: 'approval.approval.approval_pivot'));
-            $table->enum('state', [0, 1, 2])->default(0)->comment('0:PENDING, 1:APPROVED, 2:REJECTED');
+            $table->enum(column: 'state', allowed: ['pending', 'approved', 'rejected'])->default('pending');
             $table->json(config(key: 'approval.approval.new_data'))->nullable();
             $table->json(config(key: 'approval.approval.original_data'))->nullable();
             $table->timestamps();

--- a/src/Enums/ApprovalStatus.php
+++ b/src/Enums/ApprovalStatus.php
@@ -2,9 +2,9 @@
 
 namespace Cjmellor\Approval\Enums;
 
-enum ApprovalStatus: int
+enum ApprovalStatus: string
 {
-    case Pending = 0;
-    case Approved = 1;
-    case Rejected = 2;
+    case Pending = 'pending';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
 }


### PR DESCRIPTION
I decided to switch the Enum data in the `state` column in the `Approval` model to be strings instead of `int` as it just makes it a bit more obvious what is going on, and it makes it easier to use against Scopes, which I will be adding in a separate PR.