### PR TITLE
Use `whereJsonContains` instead of exact match query

### DIFF
--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -43,11 +43,10 @@ trait MustBeApproved
      */
     protected static function approvalModelExists($model): bool
     {
-        return Approval::where([
-            ['state', '=', ApprovalStatus::Pending],
-            ['new_data', '=', json_encode($model->getDirty())],
-            ['original_data', '=', json_encode($model->getOriginalMatchingChanges())],
-        ])->exists();
+        return Approval::where('state', ApprovalStatus::Pending)
+            ->whereJsonContains('new_data', $model->getDirty())
+            ->whereJsonContains('original_data', $model->getOriginalMatchingChanges())
+            ->exists();
     }
 
     /**

--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -43,6 +43,16 @@ trait MustBeApproved
      */
     protected static function approvalModelExists($model): bool
     {
+        $driver = Approval::make()->getConnection()->getConfig()['driver'] ?? 'sqlite';
+
+        if ($driver === 'sqlite') {
+            return Approval::where([
+                ['state', '=', ApprovalStatus::Pending],
+                ['new_data', '=', json_encode($model->getDirty())],
+                ['original_data', '=', json_encode($model->getOriginalMatchingChanges())],
+            ])->exists();
+        }
+
         return Approval::where('state', ApprovalStatus::Pending)
             ->whereJsonContains('new_data', $model->getDirty())
             ->whereJsonContains('original_data', $model->getOriginalMatchingChanges())


### PR DESCRIPTION
In the `approvalModelExists` check, `json_encode(...)` is being used to help check if the new/original data exists in the table before inserting a new approval. Unfortunately, this doesn't work with some DB engines (i.e. MySQL) because of formatting differences.

Using `whereJsonContains` instead seems to fix this problem. See issue #6 for more info.