### PR TITLE
Allow models to require approval only when needed

### DIFF
--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -6,22 +6,22 @@ trait MayBeApproved
 {
 
   use MustBeApproved;
-  protected bool $requiresApproval = false;
+  protected static bool $requiresApproval = false;
 
   public function isApprovalBypassed(): bool
   {
-    return (!$this->requiresApproval);
+    return (!self::$requiresApproval);
   }
 
-  public function requireApproval()
+  public function requireApproval($requires = true)
   {
-    $this->requiresApproval = true;
+    self::$requiresApproval = $requires;
   }
 
   public function withApproval(): static
   {
     $this->bypassApproval = false;
-    $this->requiresApproval = true;
+    self::$requiresApproval = true;
     return $this;
   }
 }

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -4,8 +4,16 @@ namespace Cjmellor\Approval\Concerns;
 
 trait MayBeApproved
 {
-  use MustBeApproved;
-  protected bool $bypassApproval = true;
+
+  use MustBeApproved {
+    MustBeApproved::__construct as private __parentConstruct;
+  }
+
+  public function __construct()
+  {
+    $this->__parentConstruct();
+    $this->bypassApproval = true;
+  }
 
   public function withApproval(): static
   {

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -33,6 +33,11 @@ trait MayBeApproved
   {
     print "testing " . get_class($model) . " $model->id ";
     print_r($model->getDirty());
+    return Approval::where([
+      ['state', '=', ApprovalStatus::Pending],
+      ['new_data', '=', json_encode($model->getDirty())],
+      ['original_data', '=', json_encode($model->getOriginalMatchingChanges())],
+    ])->exists();
     return Approval::where('state', ApprovalStatus::Pending)
       ->where('approvalable_id', $model->id)
       ->where('approvalable_type', get_class($model))

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -2,6 +2,7 @@
 
 namespace Cjmellor\Approval\Concerns;
 
+use Cjmellor\Approval\Enums\ApprovalStatus;
 use Cjmellor\Approval\Models\Approval;
 
 trait MayBeApproved

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -33,7 +33,7 @@ trait MayBeApproved
   {
     return Approval::where('state', ApprovalStatus::Pending)
       ->where('approvalable_id', $model->id)
-      ->where('approvalable_type', $model)
+      ->where('approvalable_type', get_class($model))
       ->whereJsonContains('new_data', $model->getDirty())
       ->exists();
   }

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -12,9 +12,4 @@ trait MayBeApproved
     $this->bypassApproval = true;
   }
 
-  public function withApproval(): static
-  {
-    $this->bypassApproval = false;
-    return $this;
-  }
 }

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -6,14 +6,28 @@ trait MayBeApproved
 {
 
   use MustBeApproved;
-  protected bool $requireApproval = false;
+  protected bool $requiresApproval = false;
 
   /**
    * Check is the approval can be bypassed.
    */
   public function isApprovalBypassed(): bool
   {
-    if ($this->requireApproval) return false;
-    return true;
+    return (!$this->requiresApproval);
+  }
+
+  public function requireApproval()
+  {
+    $this->requiresApproval = true;
+  }
+
+  /**
+   * Approval is explicitly required for this update
+   */
+  public function withApproval(): static
+  {
+    $this->bypassApproval = false;
+    $this->requiresApproval = true;
+    return $this;
   }
 }

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -8,9 +8,6 @@ trait MayBeApproved
   use MustBeApproved;
   protected bool $requiresApproval = false;
 
-  /**
-   * Check is the approval can be bypassed.
-   */
   public function isApprovalBypassed(): bool
   {
     return (!$this->requiresApproval);
@@ -21,9 +18,6 @@ trait MayBeApproved
     $this->requiresApproval = true;
   }
 
-  /**
-   * Approval is explicitly required for this update
-   */
   public function withApproval(): static
   {
     $this->bypassApproval = false;

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Cjmellor\Approval\Concerns;
+
+trait MayBeApproved
+{
+  use MustBeApproved;
+  protected bool $bypassApproval = true;
+
+  public function withApproval(): static
+  {
+    $this->bypassApproval = false;
+    return $this;
+  }
+}

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -31,6 +31,8 @@ trait MayBeApproved
    */
   protected static function approvalModelExists($model): bool
   {
+    print "testing " . get_class($model) . " $model->id ";
+    print_r($model->getDirty());
     return Approval::where('state', ApprovalStatus::Pending)
       ->where('approvalable_id', $model->id)
       ->where('approvalable_type', get_class($model))

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -8,12 +8,12 @@ trait MayBeApproved
   use MustBeApproved;
   protected static bool $requiresApproval = false;
 
-  public function isApprovalBypassed(): bool
+  public static function isApprovalBypassed(): bool
   {
-    return (!self::$requiresApproval);
+    return !self::$requiresApproval;
   }
 
-  public function requireApproval($requires = true)
+  public static function requireApproval($requires = true)
   {
     self::$requiresApproval = $requires;
   }

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -5,13 +5,10 @@ namespace Cjmellor\Approval\Concerns;
 trait MayBeApproved
 {
 
-  use MustBeApproved {
-    MustBeApproved::__construct as private __parentConstruct;
-  }
+  use MustBeApproved;
 
   public function __construct()
   {
-    $this->__parentConstruct();
     $this->bypassApproval = true;
   }
 

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -2,6 +2,8 @@
 
 namespace Cjmellor\Approval\Concerns;
 
+use Cjmellor\Approval\Models\Approval;
+
 trait MayBeApproved
 {
   use MustBeApproved;

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -8,7 +8,7 @@ trait MayBeApproved
   use MustBeApproved;
   protected static bool $requiresApproval = false;
 
-  public static function isApprovalBypassed(): bool
+  public function isApprovalBypassed(): bool
   {
     return !self::$requiresApproval;
   }

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -6,10 +6,14 @@ trait MayBeApproved
 {
 
   use MustBeApproved;
+  protected bool $requireApproval = false;
 
-  public function __construct()
+  /**
+   * Check is the approval can be bypassed.
+   */
+  public function isApprovalBypassed(): bool
   {
-    $this->bypassApproval = true;
+    if ($this->requireApproval) return false;
+    return true;
   }
-
 }

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -4,24 +4,22 @@ namespace Cjmellor\Approval\Concerns;
 
 trait MayBeApproved
 {
-
   use MustBeApproved;
   protected static bool $requiresApproval = false;
 
+  /**
+   * Check if the approval can be bypassed, based on static $requiresApproval flag;
+   */
   public function isApprovalBypassed(): bool
   {
     return !self::$requiresApproval;
   }
 
+  /**
+   * Sets the $requiresApproval flag (defaults to true)
+   */
   public static function requireApproval($requires = true)
   {
     self::$requiresApproval = $requires;
-  }
-
-  public function withApproval(): static
-  {
-    $this->bypassApproval = false;
-    self::$requiresApproval = true;
-    return $this;
   }
 }

--- a/src/Concerns/MayBeApproved.php
+++ b/src/Concerns/MayBeApproved.php
@@ -22,4 +22,16 @@ trait MayBeApproved
   {
     self::$requiresApproval = $requires;
   }
+
+  /**
+   * Check if the Approval model been created already exists with a 'pending' state
+   */
+  protected static function approvalModelExists($model): bool
+  {
+    return Approval::where('state', ApprovalStatus::Pending)
+      ->where('approvalable_id', $model->id)
+      ->where('approvalable_type', $model)
+      ->whereJsonContains('new_data', $model->getDirty())
+      ->exists();
+  }
 }

--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -66,7 +66,7 @@ trait MustBeApproved
      */
     protected function getOriginalMatchingChanges(): array
     {
-        return collect($this->getOriginal())
+        return collect($this->getRawOriginal())
             ->only(collect($this->getDirty())->keys())
             ->toArray();
     }

--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -101,4 +101,15 @@ trait MustBeApproved
 
         return $this;
     }
+
+    /**
+     * Approval is explicitly required for this update
+     */
+    public function withApproval(): static
+    {
+      $this->bypassApproval = false;
+
+      return $this;
+    }
+  
 }

--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -72,7 +72,7 @@ trait MustBeApproved
     }
 
     /**
-     * Check is the approval can be bypassed.
+     * Check if the approval can be bypassed.
      */
     public function isApprovalBypassed(): bool
     {

--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -102,14 +102,4 @@ trait MustBeApproved
         return $this;
     }
 
-    /**
-     * Approval is explicitly required for this update
-     */
-    public function withApproval(): static
-    {
-      $this->bypassApproval = false;
-
-      return $this;
-    }
-  
 }

--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -66,7 +66,7 @@ trait MustBeApproved
      */
     protected function getOriginalMatchingChanges(): array
     {
-        return collect($this->getRawOriginal())
+        return collect($this->getOriginal())
             ->only(collect($this->getDirty())->keys())
             ->toArray();
     }

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -28,11 +28,17 @@ class Approval extends Model
     return $this->morphTo();
   }
 
+  /**
+   * Mark the approval as Rejected.
+   */
   public function reject()
   {
     $this->update(['state' => ApprovalStatus::Rejected]);
   }
 
+  /**
+   * Commit the change to the DB and mark the approval as Approved.
+   */
   public function commit()
   {
     if ($this->state != ApprovalStatus::Pending) return false;
@@ -47,5 +53,13 @@ class Approval extends Model
       $this->update(['state' => ApprovalStatus::Approved]);
       return $model;
     }
+  }
+
+  /**
+   * Purge database of completed approvals older than $days.
+   */
+  public static function purge(int $days = -1)
+  {
+    self::where('created_at', '<', now()->subDays($days))->where('state', '!=', ApprovalStatus::Pending)->forceDelete();
   }
 }

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -31,6 +31,6 @@ class Approval extends Model
     public function commit()
     {
       $model = new $this->approvalable_type;
-      $model->withoutApproval()->updateOrCreate($this->new_data);
+      $model->withoutApproval()->updateOrCreate($this->new_data->toArray());
     }
 }

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -30,11 +30,10 @@ class Approval extends Model
 
   public function commit()
   {
-    $model = new $this->approvalable_type;
     if ($this->approvalable_id) {
-      $model->withoutApproval()->update($this->new_data->toArray());
+      $this->approvalable_type::find($this->approvalable_id)->withoutApproval()->update($this->new_data->toArray());
     } else {
-      $model->withoutApproval()->create($this->new_data->toArray());
+      $this->approvalable_type::withoutApproval()->create($this->new_data->toArray());
     }
   }
 }

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -31,9 +31,10 @@ class Approval extends Model
   public function commit()
   {
     if ($this->approvalable_id) {
-      $this->approvalable_type::find($this->approvalable_id)->withoutApproval()->update($this->new_data->toArray());
+      return $this->approvalable_type::find($this->approvalable_id)->withoutApproval()->update($this->new_data->toArray());
     } else {
-      $this->approvalable_type::withoutApproval()->create($this->new_data->toArray());
+      print "I'm going to create a new $this->approvable_type";
+      return $this->approvalable_type::withoutApproval()->create($this->new_data->toArray());
     }
   }
 }

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -28,15 +28,23 @@ class Approval extends Model
     return $this->morphTo();
   }
 
+  public function reject()
+  {
+    $this->update(['state' => ApprovalStatus::Rejected]);
+  }
+
   public function commit()
   {
+    if ($this->state != ApprovalStatus::Pending) return false;
     if ($this->approvalable_id) {
-      return $this->approvalable_type::find($this->approvalable_id)->withoutApproval()->update($this->new_data->toArray());
+      $model = $this->approvalable_type::find($this->approvalable_id)->withoutApproval()->update($this->new_data->toArray());
+      $this->update(['state' => ApprovalStatus::Approved]);
+      return $model;
     } else {
-      print "I'm going to create a new $this->approvable_type";
       $model = new $this->approvalable_type;
       $model->fill($this->new_data->toArray());
       $model->save();
+      $this->update(['state' => ApprovalStatus::Approved]);
       return $model;
     }
   }

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -10,27 +10,31 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class Approval extends Model
 {
-    protected $guarded = [];
+  protected $guarded = [];
 
-    protected $casts = [
-        'new_data' => AsArrayObject::class,
-        'original_data' => AsArrayObject::class,
-        'state' => ApprovalStatus::class,
-    ];
+  protected $casts = [
+    'new_data' => AsArrayObject::class,
+    'original_data' => AsArrayObject::class,
+    'state' => ApprovalStatus::class,
+  ];
 
-    public static function booted()
-    {
-        static::addGlobalScope(new ApprovalStateScope());
+  public static function booted()
+  {
+    static::addGlobalScope(new ApprovalStateScope());
+  }
+
+  public function approvalable(): MorphTo
+  {
+    return $this->morphTo();
+  }
+
+  public function commit()
+  {
+    $model = new $this->approvalable_type;
+    if ($this->approvalable_id) {
+      $model->withoutApproval()->update($this->new_data->toArray());
+    } else {
+      $model->withoutApproval()->create($this->new_data->toArray());
     }
-
-    public function approvalable(): MorphTo
-    {
-        return $this->morphTo();
-    }
-
-    public function commit()
-    {
-      $model = new $this->approvalable_type;
-      $model->withoutApproval()->updateOrCreate($this->new_data->toArray());
-    }
+  }
 }

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -34,7 +34,10 @@ class Approval extends Model
       return $this->approvalable_type::find($this->approvalable_id)->withoutApproval()->update($this->new_data->toArray());
     } else {
       print "I'm going to create a new $this->approvable_type";
-      return $this->approvalable_type::withoutApproval()->create($this->new_data->toArray());
+      $model = new $this->approvalable_type;
+      $model->fill($this->new_data->toArray());
+      $model->save();
+      return $model;
     }
   }
 }

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -27,4 +27,10 @@ class Approval extends Model
     {
         return $this->morphTo();
     }
+
+    public function commit()
+    {
+      $model = new $this->approvalable_type;
+      $model->withoutApproval()->updateOrCreate($this->new_data);
+    }
 }


### PR DESCRIPTION
For my use case, I had many crud operations already defined for my models, and only wanted approval in certain circumstances. With this PR, approval can be turned off and on as needed by attaching the trait `MayBeApproved`.


```
namespace App;

use \Illuminate\Database\Eloquent\Model;
use Cjmellor\Approval\Concerns\MayBeApproved;

class Site extends Model 
{
    use MayBeApproved;
}
```

Now, in normal use, if I want to update a particular attribute of a site, it works normally (return true). When I execute the command `requireApproval()` and then update the site, it return false and inserts the Morph into the approvals table. I can turn the requirement off again with `requireApproval(false)`

```
>>> Site::find(109)->update(['zip'=>rand()]);
[!] Aliasing 'Site' to 'App\Site' for this Tinker session.
=> true

>>> Site::requireApproval()
=> null

>>> Site::find(109)->update(['zip'=>rand()]);
=> false

>>> Site::requireApproval(false)
=> null

>>> Site::find(109)->update(['zip'=>rand()]);
=> true
```

In addition, I can also commit changes as follows

```
Site::find(109)->approvals()->first()->commit(); // commit the first approval
Site::find(109)->approvals->each->commit()    // commit all approvals
```