### PR TITLE
feature: Add optional logic to persist data on approval

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Fix styling
+          commit_message: "fix: Pint"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ Approval::where('id', 3)->postpone();
 
 In the event you need to reset a state, you can use the `withAnyState` helper.
 
+### Persisting data
+
+By default, once you approve a Model, it will be inserted into the database.
+
+If you don't want to persist to the database on approval, set a `false` flag on the  `approve` method.
+
+```php
+Approval::find(1)->approve(persist: false);
+```
+
 ## Disable Approvals
 
 If you don't want Model data to be approved, you can bypass it with the `withoutApproval` method.

--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -43,14 +43,11 @@ trait MustBeApproved
      */
     protected static function approvalModelExists($model): bool
     {
-        if ($model->make()->getConnection()->getConfig()['driver'] === 'sqlite') {
-            return self::checkDatabaseDriver($model);
-        }
-
-        return Approval::where('state', ApprovalStatus::Pending)
-            ->whereJsonContains('new_data', $model->getDirty())
-            ->whereJsonContains('original_data', $model->getOriginalMatchingChanges())
-            ->exists();
+        return Approval::where([
+            ['state', '=', ApprovalStatus::Pending],
+            ['new_data', '=', json_encode($model->getDirty())],
+            ['original_data', '=', json_encode($model->getOriginalMatchingChanges())],
+        ])->exists();
     }
 
     /**
@@ -77,19 +74,6 @@ trait MustBeApproved
     public function isApprovalBypassed(): bool
     {
         return $this->bypassApproval;
-    }
-
-    /**
-     * @param $model
-     * @return bool
-     */
-    protected static function checkDatabaseDriver($model): bool
-    {
-        return Approval::where([
-            ['state', '=', ApprovalStatus::Pending],
-            ['new_data', '=', json_encode($model->getDirty())],
-            ['original_data', '=', json_encode($model->getOriginalMatchingChanges())],
-        ])->exists();
     }
 
     /**

--- a/src/Scopes/ApprovalStateScope.php
+++ b/src/Scopes/ApprovalStateScope.php
@@ -86,7 +86,19 @@ class ApprovalStateScope implements Scope
      */
     protected function addApprove(Builder $builder)
     {
-        $builder->macro('approve', fn (Builder $builder) => $this->updateApprovalState($builder, state: ApprovalStatus::Approved));
+        $builder->macro('approve', function (Builder $builder, bool $persist = true): int {
+            if ($persist) {
+                $modelClass = $builder->getModel()->first()->approvalable_type;
+
+                $model = new $modelClass();
+
+                $model->fill($builder->getModel()->new_data->toArray());
+
+                $model->withoutApproval()->save();
+            }
+
+            return $this->updateApprovalState($builder, state: ApprovalStatus::Approved);
+        });
     }
 
     /**

--- a/src/Scopes/ApprovalStateScope.php
+++ b/src/Scopes/ApprovalStateScope.php
@@ -48,7 +48,7 @@ class ApprovalStateScope implements Scope
      */
     protected function addWithAnyState(Builder $builder)
     {
-        $builder->macro('withAnyState', fn (Builder $builder) => $builder->withoutGlobalScope($this));
+        $builder->macro('withAnyState', fn (Builder $builder): Builder => $builder->withoutGlobalScope($this));
     }
 
     /**
@@ -56,7 +56,7 @@ class ApprovalStateScope implements Scope
      */
     protected function addApproved(Builder $builder)
     {
-        $builder->macro('approved', fn (Builder $builder) => $builder
+        $builder->macro('approved', fn (Builder $builder): Builder => $builder
             ->withAnyState()
             ->where(column: 'state', operator: ApprovalStatus::Approved));
     }
@@ -66,7 +66,7 @@ class ApprovalStateScope implements Scope
      */
     protected function addPending(Builder $builder)
     {
-        $builder->macro('pending', fn (Builder $builder) => $builder
+        $builder->macro('pending', fn (Builder $builder): Builder => $builder
             ->withAnyState()
             ->where(column: 'state', operator: ApprovalStatus::Pending));
     }
@@ -76,7 +76,7 @@ class ApprovalStateScope implements Scope
      */
     protected function addRejected(Builder $builder)
     {
-        $builder->macro('rejected', fn (Builder $builder) => $builder
+        $builder->macro('rejected', fn (Builder $builder): Builder => $builder
             ->withAnyState()
             ->where(column: 'state', operator: ApprovalStatus::Rejected));
     }
@@ -106,7 +106,7 @@ class ApprovalStateScope implements Scope
      */
     protected function addPostpone(Builder $builder)
     {
-        $builder->macro('postpone', fn (Builder $builder) => $this->updateApprovalState($builder, state: ApprovalStatus::Pending));
+        $builder->macro('postpone', fn (Builder $builder): int => $this->updateApprovalState($builder, state: ApprovalStatus::Pending));
     }
 
     /**
@@ -114,7 +114,7 @@ class ApprovalStateScope implements Scope
      */
     protected function addReject(Builder $builder)
     {
-        $builder->macro('reject', fn (Builder $builder) => $this->updateApprovalState($builder, state: ApprovalStatus::Rejected));
+        $builder->macro('reject', fn (Builder $builder): int => $this->updateApprovalState($builder, state: ApprovalStatus::Rejected));
     }
 
     /**

--- a/tests/Feature/MustBeApprovedTraitTest.php
+++ b/tests/Feature/MustBeApprovedTraitTest.php
@@ -34,7 +34,8 @@ test(description: 'an approvals model is created when a model is created with Mu
     // check it has been put in the approvals' table before the fake_models table
     ->assertDatabaseHas('approvals', [
         'new_data' => json_encode([
-            'name' => 'Chris', 'meta' => 'red',
+            'name' => 'Chris',
+            'meta' => 'red',
         ]),
         'original_data' => json_encode([]),
     ])
@@ -72,10 +73,7 @@ test(description: 'an approval model cannot be duplicated', closure: function ()
 
     // check it was added to the db
     $this->assertDatabaseHas('approvals', [
-        'new_data' => json_encode([
-            'name' => 'Chris',
-            'meta' => 'red',
-        ]),
+        'new_data' => json_encode($this->fakeModelData),
     ]);
 
     // add another model with the same data...
@@ -83,4 +81,39 @@ test(description: 'an approval model cannot be duplicated', closure: function ()
 
     // as it is a duplicate, it should not be added to the DB
     $this->assertDatabaseCount('approvals', 1);
+});
+
+test(description: 'a Model is added to the corresponding table when approved', closure: function () {
+    // create a fake model with data
+    FakeModel::create($this->fakeModelData);
+
+    // check it was added to the db
+    $this->assertDatabaseHas('approvals', [
+        'new_data' => json_encode($this->fakeModelData),
+    ]);
+
+    // sanity check that is hasn't been added to the fake_models table
+    $this->assertDatabaseMissing('fake_models', $this->fakeModelData);
+
+    // approve the model
+    Approval::first()->approve();
+
+    // check it was added to the fake_models table
+    $this->assertDatabaseHas('fake_models', $this->fakeModelData);
+});
+
+test(description: 'a Model cannot be persisted when given a flag', closure: function () {
+    // create a fake model with data
+    FakeModel::create($this->fakeModelData);
+
+    // check it was added to the db
+    $this->assertDatabaseHas('approvals', [
+        'new_data' => json_encode($this->fakeModelData),
+    ]);
+
+    // approve the model
+    Approval::first()->approve(false);
+
+    // check it was added to the fake_models table
+    $this->assertDatabaseEmpty('fake_models');
 });


### PR DESCRIPTION
This PR will allow you to persist your approved data in the database.

By default, it will persist in the database as expected

```php
use App\Models\Approval;

Approval::find(1)->approve();
```

If you do not wish to persist to the database, and only update the status of the approval, you can pass a `false` flag to the `approve` method

```php
use App\Models\Approval;

Approval::find(1)->approve(persist: false);
```

Unrelated:

Return types have also been added to some of the methods in the Scope.

Within the trait, a hacky patch I had in there has been removed.