### PR TITLE
htofix: Add logic for updating data to existing data

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.1 ]
+        php: [ 8.0, 8.1, 8.2 ]
         laravel: [ 9.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.0, 8.1, 8.2 ]
+        php: [ 8.1, 8.2 ]
         laravel: [ 9.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:

--- a/src/Scopes/ApprovalStateScope.php
+++ b/src/Scopes/ApprovalStateScope.php
@@ -90,7 +90,13 @@ class ApprovalStateScope implements Scope
             if ($persist) {
                 $modelClass = $builder->getModel()->first()->approvalable_type;
 
+                $modelId = $builder->getModel()->approvalable_id;
+
                 $model = new $modelClass();
+
+                if ($modelId) {
+                    $model = $model->find($modelId);
+                }
 
                 $model->fill($builder->getModel()->new_data->toArray());
 

--- a/tests/Feature/MustBeApprovedTraitTest.php
+++ b/tests/Feature/MustBeApprovedTraitTest.php
@@ -145,5 +145,5 @@ test(description: 'a Model cannot be persisted when given a flag', closure: func
     Approval::first()->approve(false);
 
     // check it was added to the fake_models table
-    $this->assertDatabaseEmpty('fake_models');
+    $this->assertDatabaseCount('fake_models', 0);
 });


### PR DESCRIPTION
This PR adds the logic for updating a Model that already exists.

This should have been added with the v1.1.0 release but I stupidly overlooked it.