### PR TITLE
fix getting `approvalable_type`

### DIFF
--- a/src/Scopes/ApprovalStateScope.php
+++ b/src/Scopes/ApprovalStateScope.php
@@ -88,7 +88,7 @@ class ApprovalStateScope implements Scope
     {
         $builder->macro('approve', function (Builder $builder, bool $persist = true): int {
             if ($persist) {
-                $modelClass = $builder->getModel()->first()->approvalable_type;
+                $modelClass = $builder->getModel()->approvalable_type;
 
                 $modelId = $builder->getModel()->approvalable_id;
 


### PR DESCRIPTION
Hi, this is a fix to get the correct `approvalable_type`.

Using the `first()` method is not correct because it will be running an SQL query to get the first record of the approvals table