### PR TITLE
feat: Rollback Approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,13 +157,21 @@ Approval::find(1)->approve(persist: false);
 
 ## Rollbacks
 
-If you need to rollback an approval, you can use the `rollback` method.
+If you need to roll back an approval, you can use the `rollback` method.
 
 ```php
 Approval::first()->rollback();
 ```
 
-This will revert the data and set the state to `pending` and touch the `rolled_back_at` timestamp so you have a record of when it was rolled back.
+This will revert the data and set the state to `pending` and touch the `rolled_back_at` timestamp, so you have a record of when it was rolled back.
+
+### Conditional Rollbacks
+
+A roll-back can be conditional, so you can roll back an approval if a condition is met.
+
+```php
+Approval::first()->rollback(fn () => true);
+```
 
 ## Disable Approvals
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ A roll-back can be conditional, so you can roll back an approval if a condition 
 Approval::first()->rollback(fn () => true);
 ```
 
+### Events
+
+When a Model has been rolled back, a `ModelRolledBack` event will be fired with the Approval Model that was rolled back, as well as the User that rolled it back.
+
+```php
+// ModelRolledBackEvent::class
+
+public Model $approval,
+public Authenticatable|null $user,
+````
 ## Disable Approvals
 
 If you don't want Model data to be approved, you can bypass it with the `withoutApproval` method.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ If you don't want to persist to the database on approval, set a `false` flag on 
 Approval::find(1)->approve(persist: false);
 ```
 
+## Rollbacks
+
+If you need to rollback an approval, you can use the `rollback` method.
+
+```php
+Approval::first()->rollback();
+```
+
+This will revert the data and set the state to `pending` and touch the `rolled_back_at` timestamp so you have a record of when it was rolled back.
+
 ## Disable Approvals
 
 If you don't want Model data to be approved, you can bypass it with the `withoutApproval` method.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,19 @@
+# Upgrade Guide
+
+## v1.3.1 -> v1.4.0
+
+To support the new `rollback` functionality, a new migration file is needed
+
+```bash
+2023_10_09_204810_add_rolled_back_at_column_to_approvals_table
+```
+
+Be sure to migrate your database if you plan on using the `rollback` feature.
+
+If you'd prefer to do it manually, you can add the following column to your `approvals` table:
+
+```php
+Schema::table('approvals', function (Blueprint $table) {
+    $table->timestamp(column: 'rolled_back_at')->nullable()->after('original_data');
+});
+```

--- a/database/migrations/2023_10_09_204810_add_rolled_back_at_column_to_approvals_table.php
+++ b/database/migrations/2023_10_09_204810_add_rolled_back_at_column_to_approvals_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('approvals', function (Blueprint $table) {
+            $table->timestamp(column: 'rolled_back_at')->nullable()->after('original_data');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('approvals', function (Blueprint $table) {
+            $table->dropColumn(columns: 'rolled_back_at');
+        });
+    }
+};

--- a/src/ApprovalServiceProvider.php
+++ b/src/ApprovalServiceProvider.php
@@ -12,6 +12,9 @@ class ApprovalServiceProvider extends PackageServiceProvider
         $package
             ->name(name: 'approval')
             ->hasConfigFile()
-            ->hasMigration(migrationFileName: '2022_02_12_195950_create_approvals_table');
+            ->hasMigrations([
+                '2022_02_12_195950_create_approvals_table',
+                '2023_10_09_204810_add_rolled_back_at_column_to_approvals_table',
+            ]);
     }
 }

--- a/src/Events/ModelRolledBackEvent.php
+++ b/src/Events/ModelRolledBackEvent.php
@@ -2,14 +2,17 @@
 
 namespace Cjmellor\Approval\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 
 class ModelRolledBackEvent
 {
     use Dispatchable;
 
-    public function __construct()
-    {
-        //
+    public function __construct(
+        public Model $approval,
+        public Authenticatable|null $user,
+    ) {
     }
 }

--- a/src/Events/ModelRolledBackEvent.php
+++ b/src/Events/ModelRolledBackEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Cjmellor\Approval\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ModelRolledBackEvent
+{
+    use Dispatchable;
+
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -5,6 +5,7 @@ namespace Cjmellor\Approval\Models;
 use Cjmellor\Approval\Enums\ApprovalStatus;
 use Cjmellor\Approval\Events\ModelRolledBackEvent;
 use Cjmellor\Approval\Scopes\ApprovalStateScope;
+use Closure;
 use Exception;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Model;
@@ -74,8 +75,12 @@ class Approval extends Model
         }
     }
 
-    public function rollback(): void
+    public function rollback(Closure $condition = null): void
     {
+        if ($condition && ! $condition($this)) {
+            return;
+        }
+
         throw_if(
             condition: $this->state !== ApprovalStatus::Approved,
             exception: Exception::class,

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -97,6 +97,6 @@ class Approval extends Model
             'rolled_back_at' => now(),
         ]);
 
-        Event::dispatch(new ModelRolledBackEvent($this));
+        Event::dispatch(new ModelRolledBackEvent(approval: $this, user: auth()->user()));
     }
 }

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -3,10 +3,13 @@
 namespace Cjmellor\Approval\Models;
 
 use Cjmellor\Approval\Enums\ApprovalStatus;
+use Cjmellor\Approval\Events\ModelRolledBackEvent;
 use Cjmellor\Approval\Scopes\ApprovalStateScope;
+use Exception;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Facades\Event;
 
 class Approval extends Model
 {
@@ -16,6 +19,7 @@ class Approval extends Model
         'new_data' => AsArrayObject::class,
         'original_data' => AsArrayObject::class,
         'state' => ApprovalStatus::class,
+        'rolled_back_at' => 'datetime',
     ];
 
     public static function booted(): void
@@ -68,5 +72,26 @@ class Approval extends Model
         if (! $boolean) {
             $this->reject();
         }
+    }
+
+    public function rollback(): void
+    {
+        throw_if(
+            condition: $this->state !== ApprovalStatus::Approved,
+            exception: Exception::class,
+            message: 'Cannot rollback an Approval that has not been approved.'
+        );
+
+        $model = $this->approvalable;
+        $model->update($this->original_data->getArrayCopy());
+
+        $this->update([
+            'state' => ApprovalStatus::Pending,
+            'new_data' => $this->original_data,
+            'original_data' => $this->new_data,
+            'rolled_back_at' => now(),
+        ]);
+
+        Event::dispatch(new ModelRolledBackEvent($this));
     }
 }

--- a/tests/Feature/Models/ApprovalTest.php
+++ b/tests/Feature/Models/ApprovalTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Cjmellor\Approval\Enums\ApprovalStatus;
+use Cjmellor\Approval\Events\ModelRolledBackEvent;
+use Cjmellor\Approval\Tests\Models\FakeModel;
+use Illuminate\Support\Facades\Event;
+
+test(description: 'an Approved Model can be rolled back', closure: function (): void {
+        // build a query
+    $fakeModel = new FakeModel();
+
+    $fakeModel->name = 'Bob';
+    $fakeModel->meta = 'green';
+
+    // save the model, bypassing approval
+    $fakeModel->withoutApproval()->save();
+
+    // Update a fresh instance of the model
+    $fakeModel->fresh()->update(['name' => 'Chris']);
+
+    // Approve the new changes
+    $fakeModel->fresh()->approvals()->first()->approve();
+
+    // Test for Events
+    Event::fake();
+
+    // Rollback the data
+    $fakeModel->fresh()->approvals()->first()->rollback();
+
+    // Check the model has been rolled back
+    expect($fakeModel->fresh()->approvals()->first())
+        ->state->toBe(expected: ApprovalStatus::Pending)
+        ->new_data->toMatchArray(['name' => 'Bob'])
+        ->original_data->toMatchArray(['name' => 'Chris'])
+        ->rolled_back_at->not->toBeNull();
+
+    // Asser the Events were fired
+    Event::assertDispatched(ModelRolledBackEvent::class);
+});
+

--- a/tests/Feature/Models/ApprovalTest.php
+++ b/tests/Feature/Models/ApprovalTest.php
@@ -35,10 +35,13 @@ test(description: 'an Approved Model can be rolled back', closure: function (): 
         ->rolled_back_at->not->toBeNull();
 
     // Assert the Events were fired
-    Event::assertDispatched(ModelRolledBackEvent::class);
+    Event::assertDispatched(function (ModelRolledBackEvent $event) use ($fakeModel): bool {
+        return $event->approval->is($fakeModel->fresh()->approvals()->first())
+            && $event->user === null;
+    });
 });
 
-test('a rolled back Approval can be conditionally set', function () {
+test(description: 'a rolled back Approval can be conditionally set', closure: function () {
     // Build a query
     $fakeModel = new FakeModel();
 

--- a/tests/Feature/Models/ApprovalTest.php
+++ b/tests/Feature/Models/ApprovalTest.php
@@ -6,13 +6,13 @@ use Cjmellor\Approval\Tests\Models\FakeModel;
 use Illuminate\Support\Facades\Event;
 
 test(description: 'an Approved Model can be rolled back', closure: function (): void {
-        // build a query
+    // Build a query
     $fakeModel = new FakeModel();
 
     $fakeModel->name = 'Bob';
     $fakeModel->meta = 'green';
 
-    // save the model, bypassing approval
+    // Save the model, bypassing approval
     $fakeModel->withoutApproval()->save();
 
     // Update a fresh instance of the model
@@ -34,7 +34,33 @@ test(description: 'an Approved Model can be rolled back', closure: function (): 
         ->original_data->toMatchArray(['name' => 'Chris'])
         ->rolled_back_at->not->toBeNull();
 
-    // Asser the Events were fired
+    // Assert the Events were fired
     Event::assertDispatched(ModelRolledBackEvent::class);
 });
 
+test('a rolled back Approval can be conditionally set', function () {
+    // Build a query
+    $fakeModel = new FakeModel();
+
+    $fakeModel->name = 'Bob';
+    $fakeModel->meta = 'green';
+
+    // Save the model, bypassing approval
+    $fakeModel->withoutApproval()->save();
+
+    // Update a fresh instance of the model
+    $fakeModel->fresh()->update(['name' => 'Chris']);
+
+    // Approve the new changes
+    $fakeModel->fresh()->approvals()->first()->approve();
+
+    // Conditionally rollback the data
+    $fakeModel->fresh()->approvals()->first()->rollback(fn () => true);
+
+    // Check the model has been rolled back
+    expect($fakeModel->fresh()->approvals()->first())
+        ->state->toBe(expected: ApprovalStatus::Pending)
+        ->new_data->toMatchArray(['name' => 'Bob'])
+        ->original_data->toMatchArray(['name' => 'Chris'])
+        ->rolled_back_at->not->toBeNull();
+});

--- a/tests/Feature/MustBeApprovedTraitTest.php
+++ b/tests/Feature/MustBeApprovedTraitTest.php
@@ -4,33 +4,18 @@ use Cjmellor\Approval\Enums\ApprovalStatus;
 use Cjmellor\Approval\Models\Approval;
 use Cjmellor\Approval\Tests\Models\FakeModel;
 
-beforeEach(closure: function (): void {
-    $this->approvalData = [
-        'approvalable_type' => 'App\Models\FakeModel',
-        'approvalable_id' => 1,
-        'state' => ApprovalStatus::Pending,
-        'new_data' => json_encode(['name' => 'Chris']),
-        'original_data' => json_encode(['name' => 'Bob']),
-    ];
-
-    $this->fakeModelData = [
-        'name' => 'Chris',
-        'meta' => 'red',
-    ];
-});
-
 it(description: 'stores the data correctly in the database')
-    ->tap(
+    ->defer(
         fn (): Approval => Approval::create($this->approvalData)
     )->assertDatabaseHas('approvals', [
-        'approvalable_type' => 'App\Models\FakeModel',
+        'approvalable_type' => FakeModel::class,
         'approvalable_id' => 1,
         'state' => ApprovalStatus::Pending,
     ]);
 
 test(description: 'an approvals model is created when a model is created with MustBeApproved trait set')
     // create a fake model
-    ->tap(callable: fn () => FakeModel::create($this->fakeModelData))
+    ->defer(callable: fn () => FakeModel::create($this->fakeModelData))
     // check it has been put in the approvals' table before the fake_models table
     ->assertDatabaseHas('approvals', [
         'new_data' => json_encode([
@@ -92,7 +77,7 @@ test(description: 'a Model is added to the corresponding table when approved', c
         'new_data' => json_encode($this->fakeModelData),
     ]);
 
-    // sanity check that is hasn't been added to the fake_models table
+    // check that it hasn't been added to the fake_models table
     $this->assertDatabaseMissing('fake_models', $this->fakeModelData);
 
     // approve the model

--- a/tests/Feature/Scopes/ApprovalStateScopeTest.php
+++ b/tests/Feature/Scopes/ApprovalStateScopeTest.php
@@ -8,13 +8,6 @@ use Cjmellor\Approval\Models\Approval;
 use Cjmellor\Approval\Tests\Models\FakeModel;
 use Illuminate\Support\Facades\Event;
 
-beforeEach(closure: function (): void {
-    $this->fakeModelData = [
-        'name' => 'Chris',
-        'meta' => 'red',
-    ];
-});
-
 test('Check if an Approval Model is approved', closure: function (): void {
     $this->approvalData = [
         'approvalable_type' => 'App\Models\FakeModel',

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,7 +1,23 @@
 <?php
 
+use Cjmellor\Approval\Enums\ApprovalStatus;
+use Cjmellor\Approval\Tests\Models\FakeModel;
 use Cjmellor\Approval\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
-uses(TestCase::class)->in(__DIR__);
-uses(RefreshDatabase::class);
+uses(TestCase::class, RefreshDatabase::class)
+    ->beforeEach(hook: function (): void {
+        $this->approvalData = [
+            'approvalable_type' => FakeModel::class,
+            'approvalable_id' => 1,
+            'state' => ApprovalStatus::Pending,
+            'new_data' => json_encode(['name' => 'Chris']),
+            'original_data' => json_encode(['name' => 'Bob']),
+        ];
+
+        $this->fakeModelData = [
+            'name' => 'Chris',
+            'meta' => 'red',
+        ];
+    })
+    ->in(__DIR__);


### PR DESCRIPTION
This PR adds a new feature: **Approval Rollbacks**

Once a Model has been approved, you can _rollback_ to its previous state.

It will revert the new and original data and mark the reverted Approval as Pending, ready for re-approval.

**New Migration**

A new Migration was also added. This adds a new field to the `approvals` table -- `rolled_back_at` which is a timestamp which logs when the Model was rolled back.