### PR TITLE
fix: Force data approval

### DIFF
--- a/src/Scopes/ApprovalStateScope.php
+++ b/src/Scopes/ApprovalStateScope.php
@@ -104,8 +104,7 @@ class ApprovalStateScope implements Scope
                     $model = $model->find($modelId);
                 }
 
-                $model->fill($builder->getModel()->new_data->toArray());
-
+                $model->forceFill($builder->getModel()->new_data->toArray());
                 $model->withoutApproval()->save();
             }
 


### PR DESCRIPTION
This PR fixes a bug where an Approval that had constrained data (like a `user_id`) would not be present in the array when persisting the data.