### PR TITLE
Add model and user to all event constructors

### DIFF
--- a/src/Events/ModelApproved.php
+++ b/src/Events/ModelApproved.php
@@ -2,13 +2,17 @@
 
 namespace Cjmellor\Approval\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 
 class ModelApproved
 {
     use Dispatchable;
 
-    public function __construct()
-    {
+    public function __construct(
+        public Model $approval,
+        public Authenticatable|null $user,
+    ) {
     }
 }

--- a/src/Events/ModelRejected.php
+++ b/src/Events/ModelRejected.php
@@ -2,13 +2,17 @@
 
 namespace Cjmellor\Approval\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 
 class ModelRejected
 {
     use Dispatchable;
 
-    public function __construct()
-    {
+    public function __construct(
+        public Model $approval,
+        public Authenticatable|null $user,
+    ) {
     }
 }

--- a/src/Events/ModelSetPending.php
+++ b/src/Events/ModelSetPending.php
@@ -2,13 +2,17 @@
 
 namespace Cjmellor\Approval\Events;
 
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 
 class ModelSetPending
 {
     use Dispatchable;
 
-    public function __construct()
-    {
+    public function __construct(
+        public Model $approval,
+        public Authenticatable|null $user,
+    ) {
     }
 }

--- a/src/Scopes/ApprovalStateScope.php
+++ b/src/Scopes/ApprovalStateScope.php
@@ -125,14 +125,16 @@ class ApprovalStateScope implements Scope
      */
     protected function updateApprovalState(Builder $builder, ApprovalStatus $state): int
     {
+        $model = $builder
+            ->find(id: $builder->getModel()->id);
+
         match ($state) {
-            ApprovalStatus::Approved => Event::dispatch(new ModelApproved()),
-            ApprovalStatus::Pending => Event::dispatch(new ModelSetPending()),
-            ApprovalStatus::Rejected => Event::dispatch(new ModelRejected()),
+            ApprovalStatus::Approved => Event::dispatch(new ModelApproved($model, auth()->user()) ),
+            ApprovalStatus::Pending => Event::dispatch(new ModelSetPending($model, auth()->user())),
+            ApprovalStatus::Rejected => Event::dispatch(new ModelRejected($model, auth()->user())),
         };
 
-        return $builder
-            ->find(id: $builder->getModel()->id)
+        return $model
             ->update([
                 'state' => $state,
             ]);


### PR DESCRIPTION
Small change to let all events receive the model and the authenticated user that triggered it.

On second thought, I think it might be more beneficial to change the constructor parameters to receive the `Approval` model itself, instead of the eloquent model that was changed. This is because from the `Approval` we can easily get to the subject, while the opposite might not be true (when a model has multiple `Approvals`).
What do you think @cjmellor ?