### PR TITLE
feat: Bypass Approving a Rollback

### DIFF
--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -23,6 +23,10 @@ trait MustBeApproved
     {
         $filteredDirty = $model->getDirtyAttributes();
 
+        if (auth()->check()) {
+            $filteredDirty['user_id'] = auth()->id();
+        }
+
         if ($model->isApprovalBypassed() || empty($filteredDirty)) {
             return;
         }

--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -75,7 +75,7 @@ class Approval extends Model
         }
     }
 
-    public function rollback(Closure $condition = null): void
+    public function rollback(Closure $condition = null, $bypass = true): void
     {
         if ($condition && ! $condition($this)) {
             return;
@@ -87,11 +87,10 @@ class Approval extends Model
             message: 'Cannot rollback an Approval that has not been approved.'
         );
 
-        $model = $this->approvalable;
-        $model->update($this->original_data->getArrayCopy());
+        $this->approvalable->withoutApproval()->update($this->original_data->getArrayCopy());
 
         $this->update([
-            'state' => ApprovalStatus::Pending,
+            'state' => $bypass ? $this->state : ApprovalStatus::Pending,
             'new_data' => $this->original_data,
             'original_data' => $this->new_data,
             'rolled_back_at' => now(),

--- a/tests/Feature/Models/ApprovalTest.php
+++ b/tests/Feature/Models/ApprovalTest.php
@@ -5,7 +5,7 @@ use Cjmellor\Approval\Events\ModelRolledBackEvent;
 use Cjmellor\Approval\Tests\Models\FakeModel;
 use Illuminate\Support\Facades\Event;
 
-test(description: 'an Approved Model can be rolled back', closure: function (): void {
+test(description: 'an Approved Model can be rolled back and doesn\'t bypass', closure: function (): void {
     // Build a query
     $fakeModel = new FakeModel();
 
@@ -25,7 +25,7 @@ test(description: 'an Approved Model can be rolled back', closure: function (): 
     Event::fake();
 
     // Rollback the data
-    $fakeModel->fresh()->approvals()->first()->rollback();
+    $fakeModel->fresh()->approvals()->first()->rollback(bypass: false);
 
     // Check the model has been rolled back
     expect($fakeModel->fresh()->approvals()->first())
@@ -35,10 +35,35 @@ test(description: 'an Approved Model can be rolled back', closure: function (): 
         ->rolled_back_at->not->toBeNull();
 
     // Assert the Events were fired
-    Event::assertDispatched(function (ModelRolledBackEvent $event) use ($fakeModel): bool {
-        return $event->approval->is($fakeModel->fresh()->approvals()->first())
-            && $event->user === null;
-    });
+    Event::assertDispatched(fn (ModelRolledBackEvent $event): bool => $event->approval->is($fakeModel->fresh()->approvals()->first())
+        && $event->user === null);
+});
+
+test(description: 'an Approved Model can be rolled back and bypass', closure: function (): void {
+    // Build a query
+    $fakeModel = new FakeModel();
+
+    $fakeModel->name = 'Bob';
+    $fakeModel->meta = 'green';
+
+    // Save the model, bypassing approval
+    $fakeModel->withoutApproval()->save();
+
+    // Update a fresh instance of the model
+    $fakeModel->fresh()->update(['name' => 'Chris']);
+
+    // Approve the new changes
+    $fakeModel->fresh()->approvals()->first()->approve();
+
+    // Rollback the data
+    $fakeModel->fresh()->approvals()->first()->rollback();
+
+    // Check the model has been rolled back
+    expect($fakeModel->fresh()->approvals()->first())
+        ->state->toBe(expected: ApprovalStatus::Approved)
+        ->new_data->toMatchArray(['name' => 'Bob'])
+        ->original_data->toMatchArray(['name' => 'Chris'])
+        ->rolled_back_at->not->toBeNull();
 });
 
 test(description: 'a rolled back Approval can be conditionally set', closure: function () {
@@ -58,7 +83,7 @@ test(description: 'a rolled back Approval can be conditionally set', closure: fu
     $fakeModel->fresh()->approvals()->first()->approve();
 
     // Conditionally rollback the data
-    $fakeModel->fresh()->approvals()->first()->rollback(fn () => true);
+    $fakeModel->fresh()->approvals()->first()->rollback(condition: fn () => true, bypass: false);
 
     // Check the model has been rolled back
     expect($fakeModel->fresh()->approvals()->first())

--- a/tests/Feature/MustBeApprovedTraitTest.php
+++ b/tests/Feature/MustBeApprovedTraitTest.php
@@ -25,6 +25,7 @@ test(description: 'an approvals model is created when a model is created with Mu
         'new_data' => json_encode([
             'name' => 'Chris',
             'meta' => 'red',
+            'user_id' => null,
         ]),
         'original_data' => json_encode([]),
     ])

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,6 +18,7 @@ uses(TestCase::class, RefreshDatabase::class)
         $this->fakeModelData = [
             'name' => 'Chris',
             'meta' => 'red',
+            'user_id' => auth()->id(),
         ];
     })
     ->in(__DIR__);

--- a/tests/database/migrations/2022_06_20_231650_create_fake_model_table.php
+++ b/tests/database/migrations/2022_06_20_231650_create_fake_model_table.php
@@ -11,6 +11,7 @@ return new class() extends Migration
         Schema::create('fake_models', function (Blueprint $table) {
             $table->id();
             $table->string('name')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
             $table->string('meta')->nullable();
         });
     }


### PR DESCRIPTION
This PR makes a change to the `rollback` function, where by default a rollback will not require an Approval, it will bypass it.

If you want to approve roll backs, you can pass a `bypass` parameter to the function

`->rollback(bypass: false) // default is true`