### PR TITLE
fix: Rolling Back Model Fields with JSON Data

### DIFF
--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -29,10 +29,6 @@ trait MustBeApproved
             }
         }
 
-        if (auth()->check()) {
-            $filteredDirty['user_id'] = auth()->id();
-        }
-
         if ($model->isApprovalBypassed() || empty($filteredDirty)) {
             return;
         }

--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -23,6 +23,12 @@ trait MustBeApproved
     {
         $filteredDirty = $model->getDirtyAttributes();
 
+        foreach ($filteredDirty as $key => $value) {
+            if (isset($model->casts[$key]) && $model->casts[$key] === 'json') {
+                $filteredDirty[$key] = json_decode(json: $value, associative: true);
+            }
+        }
+
         if (auth()->check()) {
             $filteredDirty['user_id'] = auth()->id();
         }
@@ -141,6 +147,12 @@ trait MustBeApproved
     public function callCastAttribute($key, $value): mixed
     {
         if (array_key_exists($key, $this->casts)) {
+            // If the value is already an array, return it as is
+            if (is_array($value)) {
+                return $value;
+            }
+
+            // Otherwise, cast the attribute to its defined type
             return $this->castAttribute($key, $value);
         }
 


### PR DESCRIPTION
This PR should fix an issue where JSON data is sent to be approved.

Closes #54