### PR TITLE
feat: Extract Foreign Key from Payload

### DIFF
--- a/.github/workflows/run-pest.yml
+++ b/.github/workflows/run-pest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.2 ]
         stability: [ prefer-lowest, prefer-stable ]
 
     name: "PHP: v${{ matrix.php }} [${{ matrix.stability }}]"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .php_cs
 .php_cs.cache
+.phpunit.cache
 .phpunit.result.cache
 build
 composer.lock

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The config allows you to change the polymorphic pivot name. It should end with `
 ## Usage
 
 > The package utilises Enums, so both PHP 8.1 and Laravel 9 must be used.
-> 
+>
 > **Note** This package does not approve/deny the data for you, it just stores the new/amended data into the database. It is up to you to decide how you implement a function to approve or deny the Model.
 
 Add the `MustBeApproved` trait to your Model and now the data will be stored in an `approvals` table, ready for you to approve or deny.
@@ -87,17 +87,54 @@ Here is some info about the columns in the `approvals` table:
 
 `audited_at` => The ID of the User who set the state
 
+`foreign_key` => A foreign key to the Model that the approval is for
+
+### Bypassing Approval Check
+
 If you want to check if the Model data will be bypassed, use the `isApprovalBypassed` method.
 
 ```php
 return $model->isApprovalBypassed();
 ```
 
+### Foreign Keys for New Models
+
+> [!NOTE]
+> It is recommended to read the below section on how foreign keys work in this package.
+
+> [!IMPORTANT]
+> By default, the foreign key will always be `user_id` because this is the most common foreign key used in Laravel.
+
+If you create a new Model directly via the Model, e.g.
+
+```php
+Post::create(['title' => 'Some Title']);
+```
+
+be sure to also add the foreign key to the Model, e.g.
+
+```php
+Post::create(['title' => 'Some Title', 'user_id' => 1]);
+```
+
+Now when the Model is sent for approval, the foreign key will be stored in the `foreign_key` column.
+
+### Customise the Foreign Key
+
+Your Model might not use the `user_id` as the foreign key, so you can customise it by adding this method to your Model:
+
+```php
+public function getApprovalForeignKeyName(): string
+{
+    return 'author_id';
+}
+```
+
 ## Scopes
 
 The package comes with some helper methods for the Builder, utilising a custom scope - `ApprovalStateScope`
 
-By default, all queries to the `approvals` table will return all the Models' no matter the state. 
+By default, all queries to the `approvals` table will return all the Models' no matter the state.
 
 There are three methods to help you retrieve the state of the Approval.
 
@@ -196,6 +233,7 @@ When a Model has been rolled back, a `ModelRolledBack` event will be fired with 
 public Model $approval,
 public Authenticatable|null $user,
 ````
+
 ## Disable Approvals
 
 If you don't want Model data to be approved, you can bypass it with the `withoutApproval` method.
@@ -203,6 +241,7 @@ If you don't want Model data to be approved, you can bypass it with the `without
 ```php
 $model->withoutApproval()->update(['title' => 'Some Title']);
 ```
+
 ## Specify Approvable Attributes
 
 By default, all attributes of the model will go through the approval process, however if you only wish certain attributes to go through this process, you can specify them using the `approvalAttributes` property in your model.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,31 @@
 # Upgrade Guide
 
+## v1.4.3 -> v1.5.0
+
+A new migration needs to be run. Run:
+
+```shell
+php artisan vendor:publish
+```
+then
+
+```shell
+php artisan migrate
+```
+
+or you add the migration manually:
+
+```php
+Schema::table('approvals', function (Blueprint $table) {
+    $table->unsignedBigInteger('foreign_key')->nullable()->after('original_data');
+});
+```
+
+> [!IMPORTANT]
+> The namespace for the package has changed.
+
+Be sure to replace any instance of `Cjmellor\Approval` to `Approval\Approval`
+
 ## v1.4.2 -> 1.4.3
 
 If you wish to audit which User set the state for the Model, you need to publish and run a new Migration.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.1|^8.2",
         "illuminate/contracts": "^9.0|^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2",
-        "illuminate/contracts": "^9.0|^10.0|^11.0",
+        "php": "^8.2",
+        "illuminate/contracts": "^10.0|^11.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.0|^8.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^8.0|^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-type-coverage": "^2.0"
     },

--- a/database/migrations/2024_03_18_214515_add_foreign_id_column_to_approvals_table.php
+++ b/database/migrations/2024_03_18_214515_add_foreign_id_column_to_approvals_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('approvals', function (Blueprint $table) {
+            $table->unsignedBigInteger('foreign_key')->nullable()->after('original_data');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('approvals', function (Blueprint $table) {
+            $table->dropColumn('foreign_key');
+        });
+    }
+};

--- a/src/ApprovalServiceProvider.php
+++ b/src/ApprovalServiceProvider.php
@@ -16,6 +16,7 @@ class ApprovalServiceProvider extends PackageServiceProvider
                 '2022_02_12_195950_create_approvals_table',
                 '2023_10_09_204810_add_rolled_back_at_column_to_approvals_table',
                 '2023_11_17_002135_add_audited_by_column_to_approvals_table',
+                '2024_03_18_214515_add_foreign_id_column_to_approvals_table.php',
             ]);
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,7 +18,6 @@ uses(TestCase::class, RefreshDatabase::class)
         $this->fakeModelData = [
             'name' => 'Chris',
             'meta' => 'red',
-            'user_id' => auth()->id(),
         ];
     })
     ->in(__DIR__);


### PR DESCRIPTION
This PR aims to clean up some ways that the package handles things.

1) Until now, if you created a Model that would be approved, e.g.

```php
Comment::create(['body' => 'Hi']);
```

There would be a constraint violation when trying to approve the Model if it had a foreign key, i.e. a Comment model would normally have a relationship to a User model. Now, as long as the user adds the foreign key, everything should be okay, e.g.

```php
Comment::create(['body' => 'Hi', 'user_id' => auth()->id()]);
```

If you were to add a comment via a relationship, e.g.

```php
$user->comment()->create(['body' => 'Hi']);
```

there will be no difference, as this will always send the foreign key along with it.

2) When creating a new Model (to be approved), and it had a relationship (like a `user_id`) then that property would be added to the `new_data` JSON payload, and I just didn't like how that looked, so I have extracted it to its own column in the `approvals` table. This does mean the user needs to run a new migration though when using the next version (should be v1.5.0)