### PR TITLE
Factory support

### DIFF
--- a/src/Concerns/MustBeApprovedFactory.php
+++ b/src/Concerns/MustBeApprovedFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Cjmellor\Approval\Concerns;
+
+use Cjmellor\Approval\Enums\ApprovalStatus;
+use Cjmellor\Approval\Models\Approval;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+trait MustBeApprovedFactory
+{
+    public function withoutApproval(): Factory
+    {
+        return $this->afterMaking(function (Model $model) {
+            if (!in_array(MustBeApproved::class, class_uses($model))) {
+                $model->withoutApproval();
+            }
+        });
+    }
+}

--- a/src/Concerns/MustBeApprovedFactory.php
+++ b/src/Concerns/MustBeApprovedFactory.php
@@ -2,11 +2,8 @@
 
 namespace Cjmellor\Approval\Concerns;
 
-use Cjmellor\Approval\Enums\ApprovalStatus;
-use Cjmellor\Approval\Models\Approval;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 trait MustBeApprovedFactory
 {

--- a/src/Concerns/MustBeApprovedFactory.php
+++ b/src/Concerns/MustBeApprovedFactory.php
@@ -13,7 +13,7 @@ trait MustBeApprovedFactory
     public function withoutApproval(): Factory
     {
         return $this->afterMaking(function (Model $model) {
-            if (!in_array(MustBeApproved::class, class_uses($model))) {
+            if (in_array(MustBeApproved::class, class_uses($model))) {
                 $model->withoutApproval();
             }
         });

--- a/tests/Feature/Factories/FakeModelFactory.php
+++ b/tests/Feature/Factories/FakeModelFactory.php
@@ -12,7 +12,7 @@ class FakeModelFactory extends Factory
 
     protected $model = FakeModel::class;
 
-    public function definition():array
+    public function definition(): array
     {
         return [
             'name' => 'Bob',

--- a/tests/Feature/Factories/FakeModelFactory.php
+++ b/tests/Feature/Factories/FakeModelFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Cjmellor\Approval\Tests\Feature\Factories;
+
+use Cjmellor\Approval\Concerns\MustBeApprovedFactory;
+use Cjmellor\Approval\Tests\Models\FakeModel;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class FakeModelFactory extends Factory
+{
+    use MustBeApprovedFactory;
+
+    protected $model = FakeModel::class;
+
+    public function definition():array
+    {
+        return [
+            'name' => 'Bob',
+            'meta' => 'green',
+        ];
+    }
+}

--- a/tests/Feature/MustBeApprovedFactoryTraitTest.php
+++ b/tests/Feature/MustBeApprovedFactoryTraitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Cjmellor\Approval\Concerns\MustBeApproved;
+use Cjmellor\Approval\Enums\ApprovalStatus;
+use Cjmellor\Approval\Models\Approval;
+use Cjmellor\Approval\Tests\Models\FakeModel;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+test(description: 'a model is added via a factory when the "withoutApproval()" method is used ', closure: function () {
+    FakeModel::factory()->withoutApproval()->create();
+
+    $this->assertDatabaseHas('fake_models', [
+        'name' => 'Bob',
+        'meta' => 'green',
+    ]);
+
+    $this->assertDatabaseMissing('approvals', [
+        'new_data' => json_encode([
+            'name' => 'Bob',
+        ]),
+    ]);
+});
+
+test(description: 'many models are added via a factory when the "withoutApproval()" method is used ', closure: function () {
+    FakeModel::factory()->withoutApproval()->count(4)->create();
+
+    $this->assertCount(4, FakeModel::all());
+
+    FakeModel::all()->each(function ($model) {
+        $this->assertEquals('Bob', $model->name);
+        $this->assertEquals('green', $model->meta);
+    });
+
+    $this->assertDatabaseMissing('approvals', [
+        'new_data' => json_encode([
+            'name' => 'Bob',
+        ]),
+    ]);
+});

--- a/tests/Feature/MustBeApprovedFactoryTraitTest.php
+++ b/tests/Feature/MustBeApprovedFactoryTraitTest.php
@@ -1,12 +1,6 @@
 <?php
 
-use Cjmellor\Approval\Concerns\MustBeApproved;
-use Cjmellor\Approval\Enums\ApprovalStatus;
-use Cjmellor\Approval\Models\Approval;
 use Cjmellor\Approval\Tests\Models\FakeModel;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 test(description: 'a model is added via a factory when the "withoutApproval()" method is used ', closure: function () {
     FakeModel::factory()->withoutApproval()->create();

--- a/tests/Models/FakeModel.php
+++ b/tests/Models/FakeModel.php
@@ -3,11 +3,14 @@
 namespace Cjmellor\Approval\Tests\Models;
 
 use Cjmellor\Approval\Concerns\MustBeApproved;
+use Cjmellor\Approval\Tests\Feature\Factories\FakeModelFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class FakeModel extends Model
 {
-    use MustBeApproved;
+    use MustBeApproved, HasFactory;
 
     /**
      * @var array
@@ -18,4 +21,9 @@ class FakeModel extends Model
      * @var bool
      */
     public $timestamps = false;
+
+    protected static function newFactory(): Factory
+    {
+        return FakeModelFactory::new();
+    }
 }


### PR DESCRIPTION
My problem was discussed here: #63 and this should fix it.
I created a new MustBeApprovedFactory trait that is required on any factory for this:
```
FakeModel::factory()->withoutApproval()->create()
```
to work.