### PR TITLE
Add comprehensive test for nested array attributes in approval process

### DIFF
--- a/src/Concerns/MustBeApproved.php
+++ b/src/Concerns/MustBeApproved.php
@@ -29,7 +29,7 @@ trait MustBeApproved
         unset($filteredDirty[$foreignKey]);
 
         foreach ($filteredDirty as $key => $value) {
-            if (isset($model->casts[$key]) && $model->casts[$key] === 'json') {
+            if (isset($model->casts[$key]) && ($model->casts[$key] === 'json' || $model->casts[$key] === 'array')) {
                 $filteredDirty[$key] = json_decode(json: $value, associative: true);
             }
         }


### PR DESCRIPTION
This PR adds a new test case that validates the handling of nested array attributes through the approval process. The test ensures that:

- Multiple array-cast attributes are handled correctly
- Complex nested data structures are preserved
- Data integrity is maintained through the approval process
- Array casting works correctly after model retrieval

Fixes #68