### PR TITLE
Move spatie package tools to require instead of require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0|^11.0"
+        "illuminate/contracts": "^10.0|^11.0",
+        "spatie/laravel-package-tools": "^1.18"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
@@ -26,8 +27,7 @@
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
-        "pestphp/pest-plugin-type-coverage": "^2.0",
-        "spatie/laravel-package-tools": "^1.14.0"
+        "pestphp/pest-plugin-type-coverage": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION

This pull request includes updates to the `composer.json` file to modify package dependencies. The changes include adding a new package to the `require` section and updating the version of an existing package in the `require-dev` section.

Dependency updates:

* Added `spatie/laravel-package-tools` with version `^1.18` to the `require` section.
* Removed `spatie/laravel-package-tools` with version `^1.14.0` from the `require-dev` section.

Related to #66 