### PR TITLE
Fix Type Error

### DIFF
--- a/src/Models/Approval.php
+++ b/src/Models/Approval.php
@@ -75,7 +75,7 @@ class Approval extends Model
         }
     }
 
-    public function rollback(Closure $condition = null, $bypass = true): void
+    public function rollback(?Closure $condition = null, $bypass = true): void
     {
         if ($condition && ! $condition($this)) {
             return;


### PR DESCRIPTION
Fixes a type error I saw when running with PHP 8.4

`DEPRECATED  Cjmellor\Approval\Models\Approval::rollback(): Implicitly marking parameter $condition as nullable is deprecated, the explicit nullable type must be used instead in vendor/cjmellor/approval/src/Models/Approval.php on line 78.`